### PR TITLE
Use django-cors-headers Django module for CORS policy

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -23,5 +23,9 @@ setup(
         "drf-nested-routers",
         "django-polymorphic",
     ],
-    extras_require={"dev": ["flake8", "black", "isort", "psycopg2-binary"], "prod": ["psycopg2"]},
+    extras_require={
+        "dev": ["flake8", "black", "isort",
+                "psycopg2-binary", "django-cors-headers"],
+        "prod": ["psycopg2"]
+    },
 )

--- a/backend/wdmmgserver/settings.py
+++ b/backend/wdmmgserver/settings.py
@@ -66,6 +66,12 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+if DEBUG:
+    INSTALLED_APPS.append("corsheaders")
+    MIDDLEWARE.append("corsheaders.middleware.CorsMiddleware")
+    MIDDLEWARE.append("django.middleware.common.CommonMiddleware")
+    CORS_ALLOW_ALL_ORIGINS = True
+
 ROOT_URLCONF = 'wdmmgserver.urls'
 
 TEMPLATES = [


### PR DESCRIPTION
closes #23 

It allows all origins if `DEBUG` environment variable is true.