### PR TITLE
テンプレートダウンロード機能を追加

### DIFF
--- a/backend/wdmmgserver/settings.py
+++ b/backend/wdmmgserver/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 import os
 from pathlib import Path
+from corsheaders.defaults import default_headers
 
 from dotenv import load_dotenv
 
@@ -71,6 +72,9 @@ if DEBUG:
     MIDDLEWARE.append("corsheaders.middleware.CorsMiddleware")
     MIDDLEWARE.append("django.middleware.common.CommonMiddleware")
     CORS_ALLOW_ALL_ORIGINS = True
+    CORS_EXPOSE_HEADERS = list(default_headers) + [
+        'content-disposition',
+    ]
 
 ROOT_URLCONF = 'wdmmgserver.urls'
 

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -3,6 +3,9 @@
     <v-app-bar fixed app>
       <v-toolbar-title v-text="title" />
       <v-spacer />
+      <v-btn class="mr-4" outlined @click="downloadTemplate">
+        テンプレートをダウンロード
+      </v-btn>
       <v-btn outlined @click="handleLogout">ログアウト</v-btn>
     </v-app-bar>
     <v-main>
@@ -15,7 +18,7 @@
 
 <script>
 import Vue from 'vue'
-import { authStore } from '@/store'
+import { authStore, fileStore } from '@/store'
 
 export default Vue.extend({
   middleware: ['authenticated'],
@@ -25,6 +28,9 @@ export default Vue.extend({
     }
   },
   methods: {
+    downloadTemplate() {
+      fileStore.download()
+    },
     handleLogout() {
       authStore.signOut()
       this.$router.push('/login')

--- a/frontend/services/FileService.ts
+++ b/frontend/services/FileService.ts
@@ -1,0 +1,47 @@
+// @ts-ignore
+import authHeader from './auth-header'
+import { $axios } from '@/utils/api-accessor'
+
+const downloadBlob = (blob: Blob, fileName: string, type: string) => {
+  if (window.navigator.msSaveOrOpenBlob) {
+    // for IE,Edge
+    window.navigator.msSaveOrOpenBlob(blob, fileName)
+  } else {
+    // for chrome, firefox
+    const url = URL.createObjectURL(new Blob([blob], { type }))
+    const linkEl = document.createElement('a')
+    linkEl.href = url
+    linkEl.setAttribute('download', fileName)
+    document.body.appendChild(linkEl)
+    linkEl.click()
+
+    URL.revokeObjectURL(url)
+    linkEl.parentNode?.removeChild(linkEl)
+  }
+}
+
+const getFileNameFromContentDisposition = (disposition: string) => {
+  const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/
+  const matches = filenameRegex.exec(disposition)
+  if (matches != null && matches[1]) {
+    const fileName = matches[1].replace(/['"]/g, '')
+    return decodeURI(fileName)
+  } else {
+    return null
+  }
+}
+
+class FileService {
+  async getFile(): Promise<any> {
+    const response = await $axios.get('/transfer/xlsx_template', {
+      headers: authHeader(),
+      responseType: 'blob',
+    })
+    const disposition = response.headers['content-disposition']
+    const fileName = getFileNameFromContentDisposition(disposition) ?? 'file'
+    const type = response.headers['content-type']
+    downloadBlob(response.data, fileName, type)
+  }
+}
+
+export default new FileService()

--- a/frontend/store/modules/file.ts
+++ b/frontend/store/modules/file.ts
@@ -1,0 +1,29 @@
+import { VuexModule, Module, Action } from 'vuex-module-decorators'
+import FileService from '@/services/FileService'
+
+@Module({
+  name: 'modules/file',
+  stateFactory: true,
+  namespaced: true,
+})
+class FileModule extends VuexModule {
+  @Action({ rawError: true })
+  download(): Promise<any> {
+    return FileService.getFile().then(
+      () => {
+        return Promise.resolve()
+      },
+      (error) => {
+        const message =
+          (error.response &&
+            error.response.data &&
+            error.response.data.errorMessage) ||
+          error.message ||
+          error.toString()
+        return Promise.reject(message)
+      }
+    )
+  }
+}
+
+export default FileModule

--- a/frontend/utils/store-accessor.ts
+++ b/frontend/utils/store-accessor.ts
@@ -3,13 +3,16 @@ import { Store } from 'vuex'
 import { getModule } from 'vuex-module-decorators'
 import AuthModule from '@/store/modules/auth'
 import DataModule from '@/store/modules/data'
+import FileModule from '@/store/modules/file'
 
 let authStore: AuthModule
 let dataStore: DataModule
+let fileStore: FileModule
 
 function initialiseStores(store: Store<any>): void {
   authStore = getModule(AuthModule, store)
   dataStore = getModule(DataModule, store)
+  fileStore = getModule(FileModule, store)
 }
 
-export { initialiseStores, authStore, dataStore }
+export { initialiseStores, authStore, dataStore, fileStore }


### PR DESCRIPTION
close #37 

APIを叩いてファイルをダウンロードする機能を追加しました。
axiosで `Content-Disposition` のヘッダーが読めずにいたので苦労しました...。
参考：https://note.kiriukun.com/entry/20200303-axios-response-header-could-not-get
settings.pyで `CORS_EXPOSE_HEADERS` を設定することで解決しました。
nuxt内のメソッド名は追い追い整えます。

![スクリーンショット 2022-01-29 14 51 26](https://user-images.githubusercontent.com/14883063/151649389-e9a1008f-f5cf-4abe-99ad-48beaa9fcb3f.png)
