### PR TITLE
テンプレートダウンロードのリンクボタンを追加

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,2 @@
+ENV=development
+API_URL=http://localhost:8000

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,2 @@
+ENV=production
+API_URL=http://localhost:8000

--- a/frontend/layouts/default.vue
+++ b/frontend/layouts/default.vue
@@ -3,6 +3,13 @@
     <v-app-bar fixed app>
       <v-toolbar-title v-text="title" />
       <v-spacer />
+      <v-btn
+        class="mr-4"
+        outlined
+        :href="`${$config.apiUrl}/transfer/xlsx_template`"
+      >
+        テンプレートをダウンロード
+      </v-btn>
       <v-btn outlined @click="handleLogout">ログアウト</v-btn>
     </v-app-bar>
     <v-main>

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -60,7 +60,7 @@ export default {
   build: {},
 
   publicRuntimeConfig: {
-    authURL: process.env.AUTH_URL || 'http://localhost:8000/api-token-auth/',
+    apiUrl: process.env.API_URL || 'http://localhost:8000',
     axios: {
       baseURL: process.env.API_URL || 'http://localhost:8000',
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "nuxt",
+    "dev": "nuxt --dotenv .env.development",
     "build": "nuxt build",
     "start": "nuxt start",
-    "generate": "nuxt generate",
+    "generate": "nuxt generate --dotenv .env.production",
+    "generate:dev": "nuxt generate --dotenv .env.development",
     "lint:js": "eslint --ext \".js,.ts,.vue\" --ignore-path .gitignore .",
     "lint:style": "stylelint \"**/*.{css,scss,sass,html,vue}\" --ignore-path .gitignore",
     "lint:prettier": "prettier --check .",


### PR DESCRIPTION
close #37 

#39 の再実装です。
APIによる取得をやめて、リンクボタンに変更しました。
developmentとproductionのenvを追加し、runスクリプトを調整しています。
