### PR TITLE
Feature/issue 48 add mapped budget item api

### DIFF
--- a/backend/budgetmapper/serializers.py
+++ b/backend/budgetmapper/serializers.py
@@ -122,9 +122,28 @@ class MappedBudgetItemSerializer(serializers.ModelSerializer):
         model = models.MappedBudgetItem
         fields = (
             "id",
+            "mapped_budget",
+            "mapped_classifications",
+            "classification",
+            "created_at",
+            "updated_at",
+        )
+
+
+class MappedBudgetItemDetailSerializer(serializers.ModelSerializer):
+    classification = ClassificationSummarySerializer()
+    mapped_classifications = ClassificationSummarySerializer(many=True)
+    mapped_budget = BudgetSerializer()
+    budget = BudgetSerializer()
+
+    class Meta:
+        model = models.MappedBudgetItem
+        fields = (
+            "id",
+            "budget",
+            "mapped_budget",
             "classification",
             "mapped_classifications",
-            "mapped_budget",
             "created_at",
             "updated_at",
         )

--- a/backend/budgetmapper/serializers.py
+++ b/backend/budgetmapper/serializers.py
@@ -113,6 +113,23 @@ class BudgetDetailSerializer(serializers.ModelSerializer):
         ).data
 
 
+class MappedBudgetItemSerializer(serializers.ModelSerializer):
+    classification = ClassificationSummarySerializer()
+    mapped_classifications = ClassificationSummarySerializer(many=True)
+    mapped_budget = BudgetSerializer()
+
+    class Meta:
+        model = models.MappedBudgetItem
+        fields = (
+            "id",
+            "classification",
+            "mapped_classifications",
+            "mapped_budget",
+            "created_at",
+            "updated_at",
+        )
+
+
 class BudgetNodeSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Classification

--- a/backend/budgetmapper/serializers.py
+++ b/backend/budgetmapper/serializers.py
@@ -149,6 +149,20 @@ class MappedBudgetItemDetailSerializer(serializers.ModelSerializer):
         )
 
 
+class MappedBudgetItemCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.MappedBudgetItem
+        fields = (
+            "id",
+            "budget",
+            "mapped_budget",
+            "classification",
+            "mapped_classifications",
+            "created_at",
+            "updated_at",
+        )
+
+
 class BudgetNodeSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Classification

--- a/backend/budgetmapper/serializers.py
+++ b/backend/budgetmapper/serializers.py
@@ -149,7 +149,7 @@ class MappedBudgetItemDetailSerializer(serializers.ModelSerializer):
         )
 
 
-class MappedBudgetItemCreateSerializer(serializers.ModelSerializer):
+class MappedBudgetItemCreateUpdateSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.MappedBudgetItem
         fields = (

--- a/backend/budgetmapper/tests/factories.py
+++ b/backend/budgetmapper/tests/factories.py
@@ -49,3 +49,21 @@ class AtomicBudgetItemFactory(DjangoModelFactory):
     amount = fuzzy.FuzzyInteger(1000, high=1000000, step=1000)
     budget = factory.SubFactory(BudgetFactory)
     classification = factory.SubFactory(ClassificationFactory)
+
+
+class MappedBudgetItemFactory(DjangoModelFactory):
+    class Meta:
+        model = models.MappedBudgetItem
+
+    budget = factory.SubFactory(BudgetFactory)
+    classification = factory.SubFactory(ClassificationFactory)
+    mapped_budget = factory.SubFactory(BudgetFactory)
+
+    @factory.post_generation
+    def mapped_classificaitons(self, create, extracted, **kwargs):
+        if not create:
+            for _ in range(random.randint([1, 10])):
+                self.mapped_classifications.add(
+                    ClassificationFactory(classification_system=self.mapped_budget.classification_system)
+                )
+            return

--- a/backend/budgetmapper/tests/factories.py
+++ b/backend/budgetmapper/tests/factories.py
@@ -60,9 +60,9 @@ class MappedBudgetItemFactory(DjangoModelFactory):
     mapped_budget = factory.SubFactory(BudgetFactory)
 
     @factory.post_generation
-    def mapped_classificaitons(self, create, extracted, **kwargs):
-        if not create:
-            for _ in range(random.randint([1, 10])):
+    def mapped_classifications(self, create, extracted, **kwargs):
+        if create:
+            for _ in range(random.randint(1, 10)):
                 self.mapped_classifications.add(
                     ClassificationFactory(classification_system=self.mapped_budget.classification_system)
                 )

--- a/backend/budgetmapper/tests/test_request.py
+++ b/backend/budgetmapper/tests/test_request.py
@@ -82,12 +82,12 @@ class WdmmgTestCase(BudgetMapperTestUserAPITestCase):
         res = self.client.put(f"/api/v1/wdmmg/{bud.slug}/", {}, format="json")
         self.assertEqual(res.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    def test_delete_returns_unauthorized_error_for_non_member(self) -> None:
+    def test_destroy_returns_unauthorized_error_for_non_member(self) -> None:
         bud = factories.BudgetFactory(name="まほろ市2101年度予算", slug="mahoro-city-2101")
         res = self.client.delete(f"/api/v1/wdmmg/{bud.slug}/", {}, format="json")
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_delete_returns_method_not_allowed_error_for_member(self) -> None:
+    def test_destroy_returns_method_not_allowed_error_for_member(self) -> None:
         bud = factories.BudgetFactory(name="まほろ市2101年度予算", slug="mahoro-city-2101")
         self.client.login(username=self._user_username, password=self._user_password)
         res = self.client.delete(f"/api/v1/wdmmg/{bud.slug}/", {}, format="json")
@@ -733,7 +733,7 @@ class AtomicBudgetItemCrudTestCase(BudgetMapperTestUserAPITestCase):
             )
             self.assertEqual(res.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    def test_delete_requires_login(self):
+    def test_destroy_requires_login(self):
         cs = factories.ClassificationSystemFactory()
         budget = factories.BudgetFactory(classification_system=cs)
         budget_item = factories.AtomicBudgetItemFactory(
@@ -742,7 +742,7 @@ class AtomicBudgetItemCrudTestCase(BudgetMapperTestUserAPITestCase):
         res = self.client.delete(f"/api/v1/budgets/{budget.id}/items/{budget_item.id}/", format="json")
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_cannot_delete(self):
+    def test_cannot_destroy(self):
         cs = factories.ClassificationSystemFactory()
         budget = factories.BudgetFactory(classification_system=cs)
         budget_item = factories.AtomicBudgetItemFactory(

--- a/backend/budgetmapper/tests/test_request.py
+++ b/backend/budgetmapper/tests/test_request.py
@@ -984,3 +984,20 @@ class MappedBudgetItemCrudTestCase(BudgetMapperTestUserAPITestCase):
                 }
                 actual = res.json()
                 self.assertEqual(actual, expected)
+
+    def test_destroy_requires_login(self):
+        mbi = factories.MappedBudgetItemFactory()
+        res = self.client.delete(f"/api/v1/budgets/{mbi.budget.id}/items/{mbi.id}/", format="json")
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_destroy_requires_login(self):
+        mbi0 = factories.MappedBudgetItemFactory()
+        mbi1 = factories.MappedBudgetItemFactory()
+        mbi2 = factories.MappedBudgetItemFactory()
+        self.client.login(username=self._user_username, password=self._user_password)
+        res = self.client.delete(f"/api/v1/budgets/{mbi0.budget.id}/items/{mbi0.id}/", format="json")
+        self.assertEqual(res.status_code, status.HTTP_204_NO_CONTENT)
+        with self.assertRaises(models.MappedBudgetItem.DoesNotExist):
+            models.MappedBudgetItem.objects.get(id=mbi0.id)
+        models.MappedBudgetItem.objects.get(id=mbi1.id)
+        models.MappedBudgetItem.objects.get(id=mbi2.id)

--- a/backend/budgetmapper/tests/test_request.py
+++ b/backend/budgetmapper/tests/test_request.py
@@ -894,6 +894,17 @@ class MappedBudgetItemCrudTestCase(BudgetMapperTestUserAPITestCase):
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         expected = {
             "id": mbi01.id,
+            "budget": {
+                "id": mbi01.budget.id,
+                "name": mbi01.budget.name,
+                "slug": mbi01.budget.slug,
+                "year": mbi01.budget.year,
+                "subtitle": mbi01.budget.subtitle,
+                "classificationSystem": mbi01.budget.classification_system.id,
+                "government": mbi01.budget.government.id,
+                "createdAt": mbi01.budget.created_at.strftime(datetime_format),
+                "updatedAt": mbi01.budget.updated_at.strftime(datetime_format),
+            },
             "mappedBudget": {
                 "id": mbi01.mapped_budget.id,
                 "name": mbi01.mapped_budget.name,

--- a/backend/budgetmapper/views.py
+++ b/backend/budgetmapper/views.py
@@ -70,10 +70,12 @@ class BudgetItemViewSet(viewsets.ModelViewSet):
                 raise exceptions.MethodNotAllowed("create")
             if "mapped_budget" in self.request.data and "mapped_classifications" in self.request.data:
                 self.request.data["budget"] = self.kwargs["budget_pk"]
-                return serializers.MappedBudgetItemCreateSerializer
+                return serializers.MappedBudgetItemCreateUpdateSerializer
         if isinstance(self.get_queryset().first(), models.MappedBudgetItem):
             if self.action == "retrieve":
                 return serializers.MappedBudgetItemDetailSerializer
+            if self.action in {"update", "partial_update"}:
+                return serializers.MappedBudgetItemCreateUpdateSerializer
             return serializers.MappedBudgetItemSerializer
         if self.action in {"update", "partial_update"}:
             raise exceptions.MethodNotAllowed(self.action)

--- a/backend/budgetmapper/views.py
+++ b/backend/budgetmapper/views.py
@@ -66,6 +66,8 @@ class BudgetItemViewSet(viewsets.ModelViewSet):
 
     def get_serializer_class(self):
         if isinstance(self.get_queryset().first(), models.MappedBudgetItem):
+            if self.action == "retrieve":
+                return serializers.MappedBudgetItemDetailSerializer
             return serializers.MappedBudgetItemSerializer
         if self.action in {"update", "partial_update", "create"}:
             raise exceptions.MethodNotAllowed(self.action)

--- a/backend/budgetmapper/views.py
+++ b/backend/budgetmapper/views.py
@@ -5,7 +5,7 @@ import django_filters.rest_framework as drf_filters
 from django.http import FileResponse
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
-from rest_framework import viewsets, mixins
+from rest_framework import exceptions, mixins, viewsets
 from rest_framework.pagination import CursorPagination
 
 from . import models, serializers
@@ -56,9 +56,20 @@ class BudgetViewSet(viewsets.ModelViewSet):
         return serializers.BudgetSerializer
 
 
-class BudgetItemViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
-    serializer_class = serializers.BudgetItemSerializer
+class BudgetItemViewSet(viewsets.ModelViewSet):
     pagination_class = CreatedAtPagination
+
+    def destroy(self, request, budget_pk, pk=None):
+        if isinstance(self.get_queryset().first(), models.MappedBudgetItem):
+            return super(BudgetItemViewSet, self).destroy(request, budget_pk=budget_pk, pk=pk)
+        raise exceptions.MethodNotAllowed(self.action)
+
+    def get_serializer_class(self):
+        if isinstance(self.get_queryset().first(), models.MappedBudgetItem):
+            return serializers.MappedBudgetItemSerializer
+        if self.action in {"update", "partial_update", "create"}:
+            raise exceptions.MethodNotAllowed(self.action)
+        return serializers.BudgetItemSerializer
 
     def get_queryset(self):
         return models.BudgetItemBase.objects.filter(budget=self.kwargs["budget_pk"])

--- a/backend/budgetmapper/views.py
+++ b/backend/budgetmapper/views.py
@@ -65,11 +65,17 @@ class BudgetItemViewSet(viewsets.ModelViewSet):
         raise exceptions.MethodNotAllowed(self.action)
 
     def get_serializer_class(self):
+        if self.action == "create":
+            if "amount" in self.request.data:
+                raise exceptions.MethodNotAllowed("create")
+            if "mapped_budget" in self.request.data and "mapped_classifications" in self.request.data:
+                self.request.data["budget"] = self.kwargs["budget_pk"]
+                return serializers.MappedBudgetItemCreateSerializer
         if isinstance(self.get_queryset().first(), models.MappedBudgetItem):
             if self.action == "retrieve":
                 return serializers.MappedBudgetItemDetailSerializer
             return serializers.MappedBudgetItemSerializer
-        if self.action in {"update", "partial_update", "create"}:
+        if self.action in {"update", "partial_update"}:
             raise exceptions.MethodNotAllowed(self.action)
         return serializers.BudgetItemSerializer
 


### PR DESCRIPTION
closes #48 

add CRUD operation for MappedBudgetItem.
Same endpoint as AtomicBudgetItem but automatically change the serializers.
