### PR TITLE
feature(backend:wdmmg): fix item order on wdmmg response

### DIFF
--- a/backend/budgetmapper/tests/factories.py
+++ b/backend/budgetmapper/tests/factories.py
@@ -21,6 +21,12 @@ class ClassificationSystemFactory(DjangoModelFactory):
     level_names = ["款", "項", "目", "事業", "節", "節細"]
 
 
+def get_max_item_order_plus_one():
+    q = models.Classification.objects.order_by("-item_order")
+    if q.count() == 0:
+        return 0
+    return q[0].item_order + 1
+
 class ClassificationFactory(DjangoModelFactory):
     class Meta:
         model = models.Classification
@@ -28,6 +34,7 @@ class ClassificationFactory(DjangoModelFactory):
     name = fuzzy.FuzzyText(length=5, suffix="費")
     code = factory.LazyFunction(lambda: None if random.randint(0, 2) % 2 else str(random.randint(1, 15)))
     classification_system = factory.SubFactory(ClassificationSystemFactory)
+    item_order = fuzzy.FuzzyAttribute(get_max_item_order_plus_one)
     parent = None
 
 

--- a/backend/budgetmapper/tests/test_request.py
+++ b/backend/budgetmapper/tests/test_request.py
@@ -106,6 +106,9 @@ class WdmmgTestCase(BudgetMapperTestUserAPITestCase):
         cl1 = factories.ClassificationFactory(classification_system=cs, code="2")
         cl10 = factories.ClassificationFactory(classification_system=cs, parent=cl1, code="2.1")
         cl100 = factories.ClassificationFactory(classification_system=cs, parent=cl10, code="2.1.1")
+        cl2 = factories.ClassificationFactory(classification_system=cs, code="10")
+        cl20 = factories.ClassificationFactory(classification_system=cs, parent=cl2, code="10.1")
+        cl200 = factories.ClassificationFactory(classification_system=cs, parent=cl20, code="10.1.1")
         bud = factories.BudgetFactory(
             name="まほろ市2101年度予算", slug="mahoro-city-2101", government=gov, classification_system=cs
         )
@@ -196,6 +199,29 @@ class WdmmgTestCase(BudgetMapperTestUserAPITestCase):
                                     "name": cl100.name,
                                     "code": cl100.code,
                                     "amount": 131.0,
+                                    "children": None,
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {
+                    "id": cl2.id,
+                    "name": cl2.name,
+                    "code": cl2.code,
+                    "amount": 0,
+                    "children": [
+                        {
+                            "id": cl20.id,
+                            "name": cl20.name,
+                            "code": cl20.code,
+                            "amount": 0,
+                            "children": [
+                                {
+                                    "id": cl200.id,
+                                    "name": cl200.name,
+                                    "code": cl200.code,
+                                    "amount": 0,
                                     "children": None,
                                 }
                             ],


### PR DESCRIPTION
closes #54, closes #56 

item_order フィールドを追加しました。
既存データから migrate しようとするとエラーになると思います。`classification_system` 毎に一意になればいいので、ランダムに振ったり、`classification_system` 毎（あるいは全レコード）`created_at` で並べてレコード順に数字を振るとかで直せると思います。