### PR TITLE
feature(backend): add cache for wdmmg API

### DIFF
--- a/backend/budgetmapper/models.py
+++ b/backend/budgetmapper/models.py
@@ -1,4 +1,5 @@
-from io import BufferedIOBase, RawIOBase
+import json
+from io import BufferedIOBase, BytesIO, RawIOBase
 
 import pykakasi
 import shortuuidfield
@@ -287,7 +288,7 @@ class Blob(models.Model):
 
 class BlobChunk(models.Model):
     id = PkField()
-    blob = models.ForeignKey(Blob, on_delete=models.CASCADE, db_index=False, null=False)
+    blob = models.ForeignKey(Blob, on_delete=models.CASCADE, db_index=True, null=False)
     index = models.PositiveIntegerField(db_index=False)
     body = models.BinaryField(db_index=False)
 
@@ -318,3 +319,32 @@ class BlobReader(BufferedIOBase):
             retval = self._buffer
             self._buffer = b""
         return retval
+
+
+class WdmmgTreeCache(models.Model):
+    id = PkField()
+    blob = models.ForeignKey(Blob, on_delete=models.CASCADE, db_index=False, null=False)
+    budget = models.OneToOneField(Budget, on_delete=models.CASCADE, null=False)
+    created_at = CurrentDateTimeField()
+    updated_at = AutoUpdateCurrentDateTimeField()
+
+    @classmethod
+    def cache_tree(cls, data, budget):
+        blob = Blob.write(BytesIO(json.dumps(data).encode("utf-8")), name=budget.name)
+        try:
+            cache = cls.objects.get(budget=budget)
+            cache.blob = blob
+        except cls.DoesNotExist:
+            cache = cls(budget=budget, blob=blob)
+        cache.save()
+        return cache
+
+    @classmethod
+    def get_or_none(cls, budget):
+        try:
+            cache = cls.objects.get(budget=budget)
+        except cls.DoesNotExist:
+            return None
+        if cache.updated_at > budget.updated_at:
+            return json.load(BlobReader(cache.blob))
+        return None

--- a/backend/budgetmapper/tests/factories.py
+++ b/backend/budgetmapper/tests/factories.py
@@ -75,3 +75,8 @@ class MappedBudgetItemFactory(DjangoModelFactory):
                     ClassificationFactory(classification_system=self.mapped_budget.classification_system)
                 )
             return
+
+
+class BlobFactory(DjangoModelFactory):
+    class Meta:
+        model = models.Blob

--- a/backend/budgetmapper/tests/test_serializer.py
+++ b/backend/budgetmapper/tests/test_serializer.py
@@ -1,6 +1,8 @@
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 
-from budgetmapper import serializers
+import freezegun
+from budgetmapper import models, serializers
 from django.conf import settings
 from django.test import TestCase
 
@@ -40,3 +42,167 @@ class ClassificationSystemSerializerTestCase(TestCase):
         }
         actual = sut.data
         self.assertEqual(actual, expected)
+
+
+class WdmmgSerializerTestCase(TestCase):
+    def test_get_budgets(self):
+        gov = factories.GovernmentFactory(name="まほろ市", slug="mahoro-city")
+        cs = factories.ClassificationSystemFactory(name="まほろ市2101年一般会計", slug="mahoro-city-2101-ippan-kaikei")
+        cl0 = factories.ClassificationFactory(classification_system=cs, code="1")
+        cl00 = factories.ClassificationFactory(classification_system=cs, parent=cl0, code="1.1")
+        cl000 = factories.ClassificationFactory(classification_system=cs, parent=cl00, code="1.1.1")
+        cl001 = factories.ClassificationFactory(classification_system=cs, parent=cl00, code="1.1.2")
+        cl002 = factories.ClassificationFactory(classification_system=cs, parent=cl00, code="1.1.3")
+        cl01 = factories.ClassificationFactory(classification_system=cs, parent=cl0, code="1.2")
+        cl010 = factories.ClassificationFactory(classification_system=cs, parent=cl01, code="1.2.1")
+        cl1 = factories.ClassificationFactory(classification_system=cs, code="2")
+        cl10 = factories.ClassificationFactory(classification_system=cs, parent=cl1, code="2.1")
+        cl100 = factories.ClassificationFactory(classification_system=cs, parent=cl10, code="2.1.1")
+        cl2 = factories.ClassificationFactory(classification_system=cs, code="10")
+        cl20 = factories.ClassificationFactory(classification_system=cs, parent=cl2, code="10.1")
+        cl200 = factories.ClassificationFactory(classification_system=cs, parent=cl20, code="10.1.1")
+        bud = factories.BudgetFactory(
+            name="まほろ市2101年度予算", slug="mahoro-city-2101", government=gov, classification_system=cs
+        )
+
+        abi000 = factories.AtomicBudgetItemFactory(value=123.0, budget=bud, classification=cl000)
+        abi001 = factories.AtomicBudgetItemFactory(value=125.0, budget=bud, classification=cl001)
+        abi002 = factories.AtomicBudgetItemFactory(value=127.0, budget=bud, classification=cl002)
+        abi010 = factories.AtomicBudgetItemFactory(value=129.0, budget=bud, classification=cl010)
+        abi100 = factories.AtomicBudgetItemFactory(value=131.0, budget=bud, classification=cl100)
+
+        expected = [
+            {
+                "id": cl0.id,
+                "name": cl0.name,
+                "code": cl0.code,
+                "amount": abi000.amount + abi001.amount + abi002.amount + abi010.amount,
+                "children": [
+                    {
+                        "id": cl00.id,
+                        "name": cl00.name,
+                        "code": cl00.code,
+                        "amount": abi000.amount + abi001.amount + abi002.amount,
+                        "children": [
+                            {
+                                "id": cl000.id,
+                                "name": cl000.name,
+                                "code": cl000.code,
+                                "amount": abi000.amount,
+                                "children": None,
+                            },
+                            {
+                                "id": cl001.id,
+                                "name": cl001.name,
+                                "code": cl001.code,
+                                "amount": abi001.amount,
+                                "children": None,
+                            },
+                            {
+                                "id": cl002.id,
+                                "name": cl002.name,
+                                "code": cl002.code,
+                                "amount": abi002.amount,
+                                "children": None,
+                            },
+                        ],
+                    },
+                    {
+                        "id": cl01.id,
+                        "name": cl01.name,
+                        "code": cl01.code,
+                        "amount": abi010.amount,
+                        "children": [
+                            {
+                                "id": cl010.id,
+                                "name": cl010.name,
+                                "code": cl010.code,
+                                "amount": abi010.amount,
+                                "children": None,
+                            }
+                        ],
+                    },
+                ],
+            },
+            {
+                "id": cl1.id,
+                "name": cl1.name,
+                "code": cl1.code,
+                "amount": abi100.amount,
+                "children": [
+                    {
+                        "id": cl10.id,
+                        "name": cl10.name,
+                        "code": cl10.code,
+                        "amount": abi100.amount,
+                        "children": [
+                            {
+                                "id": cl100.id,
+                                "name": cl100.name,
+                                "code": cl100.code,
+                                "amount": abi100.amount,
+                                "children": None,
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "id": cl2.id,
+                "name": cl2.name,
+                "code": cl2.code,
+                "amount": 0,
+                "children": [
+                    {
+                        "id": cl20.id,
+                        "name": cl20.name,
+                        "code": cl20.code,
+                        "amount": 0,
+                        "children": [
+                            {
+                                "id": cl200.id,
+                                "name": cl200.name,
+                                "code": cl200.code,
+                                "amount": 0,
+                                "children": None,
+                            }
+                        ],
+                    }
+                ],
+            },
+        ]
+        actual = serializers.WdmmgSerializer().get_budgets(obj=bud)
+        self.assertEqual(actual, expected)
+
+    def test_get_budgets_creates_cache(self):
+        import json
+
+        bud = factories.BudgetFactory()
+        cs = bud.classification_system
+        c0 = factories.ClassificationFactory(classification_system=cs, parent=None)
+        c00 = factories.ClassificationFactory(classification_system=cs, parent=c0)
+        c01 = factories.ClassificationFactory(classification_system=cs, parent=c0)
+        abi00 = factories.AtomicBudgetItemFactory(budget=bud, classification=c00)
+
+        expected = json.dumps(
+            [
+                {
+                    "id": c0.id,
+                    "name": c0.name,
+                    "code": c0.code,
+                    "amount": abi00.amount,
+                    "children": [
+                        {"id": c00.id, "name": c00.name, "code": c00.code, "amount": abi00.amount, "children": None},
+                        {"id": c01.id, "name": c01.name, "code": c01.code, "amount": 0, "children": None},
+                    ],
+                }
+            ]
+        ).encode("utf-8")
+        serializers.WdmmgSerializer().get_budgets(obj=bud)
+        cache = models.WdmmgTreeCache.objects.get(budget=bud)
+        actual = models.BlobReader(cache.blob).read()
+        self.assertEqual(actual, expected)
+
+    def test_get_budgets_uses_cache_when_budget_is_older(self):
+        with freezegun.freeze_time(datetime(2021, 1, 31, 12, 23, 34, 5678)) as dt:
+            bud = factories.BudgetFactory()


### PR DESCRIPTION
closes #33 

9秒ほど掛かっていた cofog の計算が、キャッシュ後は 0 秒になりました。

```
% echo $(date +%H:%M:%S) && curl localhost:8000/api/v1/wdmmg/tsukuba-shi-cofog2021/ | wc && echo $(date +%H:%M:%S)
18:40:50
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21664  100 21664    0     0   2295      0  0:00:09  0:00:09 --:--:--  5120
      0      32   21664
18:41:00
% echo $(date +%H:%M:%S) && curl localhost:8000/api/v1/wdmmg/tsukuba-shi-cofog2021/ | wc && echo $(date +%H:%M:%S)
18:41:01
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21664  100 21664    0     0  1511k      0 --:--:-- --:--:-- --:--:-- 1511k
      0      32   21664
18:41:01
```

Budget オブジェクトの updated_at と見比べて古くなっていたら作り直すようになっています。現状は Budget オブジェクトの子要素が変わっても Budget オブジェクトの updated_at が更新されたりしないので、その辺りを作り込む必要があります。
#102 に引き継ぎます