### PR TITLE
Serve staticfiles in production environment

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -5,6 +5,7 @@ on: push
 env:
   APPLICATION_SECRET_KEY: key
   APPLICATION_DATABASE_PASSWORD: postgres
+  APPLICATION_DEBUG: True
 
 jobs:
   build:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,11 @@
       "request": "launch",
       "cwd": "${workspaceFolder}/backend",
       "program": "${workspaceFolder}/backend/.venv/bin/flake8",
-      "args": ["--exclude", ".venv,budgetmapper/migrations", "--max-line-length=120"]
+      "args": [
+        "--exclude",
+        ".venv,budgetmapper/migrations",
+        "--max-line-length=120"
+      ]
     },
     {
       "name": "Test",
@@ -33,6 +37,19 @@
       "args": ["runserver"],
       "env": {
         "APPLICATION_DEBUG": "True"
+      },
+      "django": true
+    },
+    {
+      "name": "Django (DEBUG = False)",
+      "type": "python",
+      "justMyCode": false,
+      "request": "launch",
+      "cwd": "${workspaceFolder}/backend",
+      "program": "${workspaceFolder}/backend/manage.py",
+      "args": ["runserver"],
+      "env": {
+        "APPLICATION_ALLOWED_HOSTS": "localhost"
       },
       "django": true
     }

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -33,6 +33,6 @@ setup(
             "freezegun",
             "django-extensions",
         ],
-        "prod": ["psycopg2"],
+        "prod": ["psycopg2", "whitenoise"],
     },
 )

--- a/backend/wdmmgserver/settings.py
+++ b/backend/wdmmgserver/settings.py
@@ -72,6 +72,8 @@ if DEBUG:
     MIDDLEWARE.append("corsheaders.middleware.CorsMiddleware")
     MIDDLEWARE.append("django.middleware.common.CommonMiddleware")
     CORS_ALLOW_ALL_ORIGINS = True
+else:
+    MIDDLEWARE.append("whitenoise.middleware.WhiteNoiseMiddleware")
 
 ROOT_URLCONF = 'wdmmgserver.urls'
 


### PR DESCRIPTION
Use WhiteNoise to serve STATICFILES in production environment.

http://whitenoise.evans.io/en/stable/django.html

`DEBUG` が `False` の環境でも静的なファイルを Django から配信する PR です。

リバースプロキシの設定や運用を減らすには WhiteNoise を使って配信する方針もありかと思い、出しました。


マージするかは少し議論が必要かもです。特に不具合は確認されていないものの Django の流儀からは外れるところがあります。