### PR TITLE
Serve `frontend` contents via Nginx

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -5,14 +5,18 @@ server {
 
     listen 80;
 
-    location / {
+    location ~ ^(/admin/|/api/v1/|/transfer/|/icons/|/api-token-auth/) {
         proxy_pass http://wdmmg-server;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;
     }
 
-    location /static/ {
+    location / {
+     alias /app/static/;
+    }
+
+    location /static {
      alias /app/static/;
     }
 }


### PR DESCRIPTION
close #144 

`frontend` のコンテンツも Nginx を経由して配信するために Nginx の設定を修正しました。

Django でルーティングする URL パス以外は`frontend` のコンテンツを表示するような感じにしてみましたが、よく考えると `/` は `openspending-backend/frontend` ではなくて `openspending-frontend` の成果物が表示されるのが正しいのかもしれないです。

ほか `frontend` のコンテンツのリンク先が `localhost:8080` の指定になっているようなので対応が必要そうです。

上記について考慮する必要があるので、ドラフトとして出しておきます。