### PR TITLE
dev env and prod env need `django-cors-headers`

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -21,6 +21,7 @@ setup(
         "drf-nested-routers",
         "django-polymorphic",
         "django",
+        "django-cors-headers",
     ],
     extras_require={
         "dev": [
@@ -28,7 +29,6 @@ setup(
             "black",
             "isort",
             "psycopg2-binary",
-            "django-cors-headers",
             "factory-boy",
             "freezegun",
             "django-extensions",


### PR DESCRIPTION
本番環境でも `django-cors-headers` が必要になったので必須パッケージに移動しています。